### PR TITLE
Use trimspace instead of trim

### DIFF
--- a/module/main.tf
+++ b/module/main.tf
@@ -34,7 +34,7 @@ locals {
       rdma           = local.driver_rdma_block
     },
     # Only include "version" when non-null/non-empty
-    var.driver_version != null && trim(var.driver_version) != "" ? { version = var.driver_version } : {} 
+    var.driver_version != null && trimspace(var.driver_version) != "" ? { version = var.driver_version } : {} 
   )
 
   inline_values = {


### PR DESCRIPTION
`trim` expects a second argument `cutset` to be removed.  `trimspace` removes all whitespace from start and end.

Currently, on specifying any `driver_version`, we get an error:

```
╷
│ Error: Not enough function arguments
│
│   on main.tf line 37, in locals:
│   37:     var.driver_version != null && trim(var.driver_version) != "" ? { version = var.driver_version } : {}
│     ├────────────────
│     │ while calling trim(str, cutset)
│     │ var.driver_version is "580.126.16"
│
│ Function "trim" expects 2 argument(s). Missing value for "cutset".
╵
```